### PR TITLE
fix clear_database that can't find a populated PuppetDBExtensions.config

### DIFF
--- a/acceptance/helper.rb
+++ b/acceptance/helper.rb
@@ -564,18 +564,18 @@ EOS
   end
 
   def clear_database(host)
-    case PuppetDBExtensions.config[:database]
-      when :postgres
+    case options[:puppetdb_database]
+      when 'postgres'
         if host.is_pe?
           on host, 'su - pe-postgres -s "/bin/bash" -c "/opt/puppet/bin/dropdb pe-puppetdb"'
         else
           on host, 'su postgres -c "dropdb puppetdb"'
         end
         install_postgres(host)
-      when :embedded
+      when 'embedded'
         on host, "rm -rf #{puppetdb_sharedir(host)}/db/*"
       else
-        raise ArgumentError, "Unsupported database: '#{PuppetDBExtensions.config[:database]}'"
+        raise ArgumentError, "Unsupported database: '#{options[:puppetdb_database]}'"
     end
   end
 
@@ -1030,7 +1030,7 @@ PP
         'storeconfigs' => 'true',
         'storeconfigs_backend' => 'puppetdb',
         'autosign' => 'true',
-      }
+      },
       'main' => {
         'environmentpath' => manifest_path,
       }} do


### PR DESCRIPTION
use the options hash instead.
also fix john's previous fix to run_agents_with_new_site_pp.

this allows tests/anonymize/anonymize_profile.rb to run assuming other tests are able to teardown properly.
